### PR TITLE
infra(pool-a): matrix shards to beat GHA 6h hard cap

### DIFF
--- a/.github/workflows/capy_pool_a.yml
+++ b/.github/workflows/capy_pool_a.yml
@@ -1,21 +1,21 @@
 name: Capy Pool A — Horse Profiles + Trackwork + Injury
 
-# Pool A = horse-heavy scrapers. Runs sequentially:
-#   HorseData_Scraper.py       — profiles + pedigree + form records
-#   HorseTrackwork_Scraper.py  — morning trackwork history
-#   HorseInjury_Scraper.py     — injury/retirement status (requests-based)
+# Matrix architecture (2026-04-25): splits the 3 scrapers across parallel
+# jobs, each with their own 6h GHA-hosted budget. HorseData + HorseTrackwork
+# are sharded across 4 partitions via CRC32(horse_no) so per-shard wallclock
+# drops below 2h.
 #
-# Cutover status: FULL CUTOVER as of 2026-04-24.
-# Replit VM confirmed stopped (last periodic-backup commit 2026-04-23 06:25 UTC,
-# silent >26h since). Date gate lifted — Pool A is now the sole owner of
-# horse profile / trackwork / injury scraping.
+# Replaces the single-job sequential design that consistently hit GHA's
+# hard 6-hour ubuntu-latest cap (the previous `timeout-minutes: 720` was
+# silently truncated to 360 by GitHub's policy).
 #
-# The daily cron runs at HK 04:00 (UTC 20:00), ~4 hours after race_daily completes,
-# so the lifecycle classifier sees fresh last_race_date values.
+# Jobs graph:
+#   guard -> horse-data[0..3] -+-> horse-trackwork[0..3] -+-> push
+#                              +-> horse-injury          -+
 #
-# Additional fixture-aware guard: skip Pool A unless yesterday was a race day
-# (Pool A depends on fresh last_race_date), saving GHA minutes on non-race-adjacent
-# days. Override via dispatch input `force=true`.
+# Cutover status: FULL CUTOVER as of 2026-04-24. Pool A is the sole owner
+# of horse profile / trackwork / injury scraping. Replit VM confirmed
+# stopped since 2026-04-23.
 
 on:
   schedule:
@@ -23,21 +23,50 @@ on:
   workflow_dispatch:
     inputs:
       skip_scrapers:
-        description: 'Comma-separated scrapers to skip (e.g. HorseTrackwork,HorseInjury)'
+        description: 'Skip list (HorseData,HorseTrackwork,HorseInjury)'
         required: false
         default: ''
       force:
-        description: 'Bypass cutover + fixture guards (true/false)'
+        description: 'Bypass fixture guard (true/false)'
         required: false
         default: 'false'
 
 permissions:
   contents: write
 
+env:
+  TOTAL_SHARDS: 4
+
 jobs:
-  pool-a:
+  guard:
     runs-on: ubuntu-latest
-    timeout-minutes: 720  # 12h: first-pass covers ~1300 horses, ~20s each incl page load
+    outputs:
+      run: ${{ steps.g.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+      - id: g
+        name: Fixture gate
+        run: |
+          FORCE="${{ github.event.inputs.force }}"
+          if [ "$FORCE" = "true" ]; then
+            echo "force=true — bypassing fixture guard"
+            echo "run=true" >> $GITHUB_OUTPUT
+          else
+            bash scripts/fixture_guard.sh --window 1 --direction past
+          fi
+
+  horse-data:
+    needs: guard
+    if: needs.guard.outputs.run == 'true' && !contains(github.event.inputs.skip_scrapers, 'HorseData')
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -45,69 +74,176 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Pre-flight - fixture guard (cutover gate removed 2026-04-24)
-        id: guard
-        run: |
-          FORCE="${{ github.event.inputs.force }}"
-
-          if [ "$FORCE" = "true" ]; then
-            echo "force=true - bypassing fixture guard"
-            echo "run=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-
-          # Fixture-aware: run only if yesterday was a race day
-          bash scripts/fixture_guard.sh --window 1 --direction past
-
       - uses: actions/setup-python@v5
-        if: steps.guard.outputs.run == 'true'
         with:
           python-version: '3.12'
 
-      - name: Setup Chrome
+      - uses: browser-actions/setup-chrome@v1
         id: chrome
-        if: steps.guard.outputs.run == 'true'
-        uses: browser-actions/setup-chrome@v1
         with:
           chrome-version: stable
 
-      - name: Setup ChromeDriver
-        if: steps.guard.outputs.run == 'true'
-        uses: nanasess/setup-chromedriver@v2
+      - uses: nanasess/setup-chromedriver@v2
 
       - name: Export browser paths
-        if: steps.guard.outputs.run == 'true'
         run: |
           echo "CHROMIUM_PATH=${{ steps.chrome.outputs.chrome-path }}" >> $GITHUB_ENV
           echo "CHROMEDRIVER_PATH=$(which chromedriver)" >> $GITHUB_ENV
 
       - name: Install Python deps
-        if: steps.guard.outputs.run == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Run Pool A scrapers
-        if: steps.guard.outputs.run == 'true'
+      - name: Run HorseData shard ${{ matrix.shard }}
         run: |
-          SKIP="${{ github.event.inputs.skip_scrapers }}"
-          for scraper in HorseData_Scraper.py HorseTrackwork_Scraper.py HorseInjury_Scraper.py; do
-            short=$(echo "$scraper" | sed 's/_Scraper\.py//')
-            if echo ",$SKIP," | grep -q ",$short,"; then
-              echo "::group::Skipping $scraper"
-              echo "  skipped by dispatch input"
-              echo "::endgroup::"
-              continue
-            fi
-            echo "::group::$scraper"
-            python "$scraper" || echo "  $scraper exited non-zero — continuing"
-            echo "::endgroup::"
-          done
+          python HorseData_Scraper.py \
+            --shard ${{ matrix.shard }} \
+            --total-shards ${{ env.TOTAL_SHARDS }} \
+            || echo "HorseData shard ${{ matrix.shard }} exited non-zero — uploading partial"
 
-      - name: Push Pool A data to main
-        if: steps.guard.outputs.run == 'true'
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pool-a-horsedata-shard-${{ matrix.shard }}
+          path: |
+            horses/profiles/horse_profiles.csv
+            horses/form_records/
+            failed_horses.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  horse-trackwork:
+    needs: horse-data
+    if: always() && needs.horse-data.result != 'cancelled' && needs.horse-data.result != 'skipped' && !contains(github.event.inputs.skip_scrapers, 'HorseTrackwork')
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download horse-data artefacts (for horse_profiles.csv)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pool-a-horsedata-shard-*
+          merge-multiple: true
+          path: .
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: browser-actions/setup-chrome@v1
+        id: chrome
+        with:
+          chrome-version: stable
+
+      - uses: nanasess/setup-chromedriver@v2
+
+      - name: Export browser paths
+        run: |
+          echo "CHROMIUM_PATH=${{ steps.chrome.outputs.chrome-path }}" >> $GITHUB_ENV
+          echo "CHROMEDRIVER_PATH=$(which chromedriver)" >> $GITHUB_ENV
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run HorseTrackwork shard ${{ matrix.shard }}
+        run: |
+          python HorseTrackwork_Scraper.py \
+            --shard ${{ matrix.shard }} \
+            --total-shards ${{ env.TOTAL_SHARDS }} \
+            || echo "HorseTrackwork shard ${{ matrix.shard }} exited non-zero — uploading partial"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pool-a-trackwork-shard-${{ matrix.shard }}
+          path: |
+            horses/trackwork/
+            failed_trackwork.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  horse-injury:
+    needs: horse-data
+    if: always() && needs.horse-data.result != 'cancelled' && needs.horse-data.result != 'skipped' && !contains(github.event.inputs.skip_scrapers, 'HorseInjury')
+    runs-on: ubuntu-latest
+    timeout-minutes: 350
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download horse-data artefacts (for horse_profiles.csv)
+        uses: actions/download-artifact@v4
+        with:
+          pattern: pool-a-horsedata-shard-*
+          merge-multiple: true
+          path: .
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run HorseInjury (requests-based, single job)
+        run: python HorseInjury_Scraper.py || echo "HorseInjury exited non-zero — uploading partial"
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: pool-a-injury
+          path: |
+            horses/injury/
+            failed_injury.log
+          if-no-files-found: warn
+          retention-days: 7
+
+  push:
+    needs: [horse-data, horse-trackwork, horse-injury]
+    if: always() && (needs.horse-data.result == 'success' || needs.horse-trackwork.result == 'success' || needs.horse-injury.result == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 1
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download all artefacts
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/artifacts
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install merge deps
+        run: pip install pandas
+
+      - name: Merge artefacts into working tree
+        run: python scripts/merge_pool_a_artifacts.py /tmp/artifacts
+
+      - name: Push merged data to main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python git_sync.py \
-            --message "[data][skip ci] pool-a $(date -u +%Y-%m-%dT%H:%MZ) via GHA"
+          python git_sync.py --message "pool-a $(date -u +%Y-%m-%dT%H:%MZ) via GHA matrix"

--- a/HorseData_Scraper.py
+++ b/HorseData_Scraper.py
@@ -9,6 +9,8 @@ Output:
 """
 
 import os, re, time
+import argparse
+import zlib
 import logging
 from datetime import date
 import pandas as pd
@@ -23,6 +25,17 @@ from lifecycle_helper import (
 )
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# ── CLI: shard control for parallel GHA matrix runs ─────────────────────────
+# When --total-shards > 1, filter the horse_no set to only those matching
+# CRC32(horse_no) % total_shards == shard. Deterministic across runners
+# (unlike Python's hash() which is PYTHONHASHSEED-randomized).
+_ap = argparse.ArgumentParser()
+_ap.add_argument("--shard", type=int, default=0,
+                 help="Shard index (0..total_shards-1) for matrix runs.")
+_ap.add_argument("--total-shards", type=int, default=1,
+                 help="Total shard count. 1 = no sharding (full pass).")
+_ARGS = _ap.parse_args()
 
 RESULTS_DIR  = "data"
 PROFILES_DIR = os.path.join("horses", "profiles")
@@ -59,6 +72,13 @@ for year in sorted(os.listdir(RESULTS_DIR)):
             print(f"  Error reading {fname}: {e}")
 
 print(f"Found {len(horse_nos)} unique horses.")
+
+# ── Shard filter (GHA matrix) — partition by CRC32(horse_no) ────────────────
+if _ARGS.total_shards > 1:
+    before = len(horse_nos)
+    horse_nos = {h for h in horse_nos
+                 if zlib.crc32(h.encode()) % _ARGS.total_shards == _ARGS.shard}
+    print(f"Shard {_ARGS.shard}/{_ARGS.total_shards}: filtered {before} → {len(horse_nos)} horses")
 
 # ── 2. Determine which horses still need scraping ───────────────────────────
 

--- a/HorseTrackwork_Scraper.py
+++ b/HorseTrackwork_Scraper.py
@@ -13,6 +13,8 @@ Output:
 """
 
 import os, re, time
+import argparse
+import zlib
 import logging
 import pandas as pd
 from selenium.webdriver.common.by import By
@@ -22,6 +24,15 @@ from comeback_detection import should_scrape
 from lifecycle_helper import compute_last_race_dates, load_horse_state, load_today_entries
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+# ── CLI: shard control for parallel GHA matrix runs ─────────────────────────
+# Mirrors HorseData_Scraper.py. CRC32(horse_no) % total_shards == shard.
+_ap = argparse.ArgumentParser()
+_ap.add_argument("--shard", type=int, default=0,
+                 help="Shard index (0..total_shards-1) for matrix runs.")
+_ap.add_argument("--total-shards", type=int, default=1,
+                 help="Total shard count. 1 = no sharding (full pass).")
+_ARGS = _ap.parse_args()
 PROFILES_FILE = os.path.join("horses", "profiles", "horse_profiles.csv")
 
 RESULTS_DIR   = "data"
@@ -56,6 +67,15 @@ for year in sorted(os.listdir(RESULTS_DIR)):
             pass
 
 print(f"Found {len(horse_nos)} unique horses.")
+
+# ── Shard filter (GHA matrix) — partition by CRC32(horse_no) ────────────────
+# Applied BEFORE the "already done" subtraction so each shard's done/todo
+# computation is scoped to its partition.
+if _ARGS.total_shards > 1:
+    before = len(horse_nos)
+    horse_nos = {h for h in horse_nos
+                 if zlib.crc32(h.encode()) % _ARGS.total_shards == _ARGS.shard}
+    print(f"Shard {_ARGS.shard}/{_ARGS.total_shards}: filtered {before} → {len(horse_nos)} horses")
 
 done = {f.replace("trackwork_", "").replace(".csv", "") for f in os.listdir(TRACKWORK_DIR) if f.endswith(".csv")}
 todo_raw = sorted(horse_nos - done)

--- a/scripts/merge_pool_a_artifacts.py
+++ b/scripts/merge_pool_a_artifacts.py
@@ -1,0 +1,97 @@
+"""Merge Pool A shard artifacts into the working tree.
+
+Each horse-data shard uploads a horse_profiles.csv equal to
+[committed baseline + its shard's appended rows]. Per-horse files
+(form_<hno>.csv / trackwork_<hno>.csv / injury_<hno>.csv) never collide
+across shards because shards partition horse_no via CRC32.
+
+Dedup strategy for horse_profiles.csv:
+  Concat all shard copies, then drop_duplicates on horse_no keeping the
+  row with the latest profile_last_scraped. This correctly prefers
+  newly-scraped rows over stale baseline copies from other shards'
+  fresh checkouts — even when pandas sort ordering would otherwise pick
+  a stale baseline row as "last".
+
+Usage (run from repo root):
+  python scripts/merge_pool_a_artifacts.py /tmp/artifacts
+"""
+import shutil
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+
+def main(art_dir: str) -> int:
+    ART = Path(art_dir)
+    ROOT = Path.cwd()
+
+    if not ART.is_dir():
+        print(f"artifact dir not found: {ART}", file=sys.stderr)
+        return 1
+
+    # ── 1. Copy per-horse CSVs (form_/trackwork_/injury_) ──────────────────
+    # These files are partitioned by horse_no so no cross-shard collision
+    # should occur. If one does (bug), the last-copy wins (benign).
+    copied = {"form_records": 0, "trackwork": 0, "injury": 0}
+    for subdir_name in ("form_records", "trackwork", "injury"):
+        tgt = ROOT / "horses" / subdir_name
+        tgt.mkdir(parents=True, exist_ok=True)
+        for src in ART.rglob(f"horses/{subdir_name}/*"):
+            if src.is_file() and src.name != "_horseid_map.json":
+                shutil.copy2(src, tgt / src.name)
+                copied[subdir_name] += 1
+    for k, n in copied.items():
+        print(f"  copied {n} files into horses/{k}/")
+
+    # ── 2. Merge horse_profiles.csv shards ────────────────────────────────
+    dfs = []
+    for p in ART.rglob("horse_profiles.csv"):
+        try:
+            dfs.append(pd.read_csv(p, encoding="utf-8-sig"))
+            print(f"  loaded {p} ({len(dfs[-1])} rows)")
+        except Exception as e:
+            print(f"  skip {p}: {e}")
+
+    if dfs:
+        concat = pd.concat(dfs, ignore_index=True)
+        if "profile_last_scraped" in concat.columns:
+            concat = concat.sort_values(
+                "profile_last_scraped", na_position="first"
+            )
+        merged = concat.drop_duplicates(subset="horse_no", keep="last")
+        out = ROOT / "horses" / "profiles" / "horse_profiles.csv"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        merged.to_csv(out, index=False, encoding="utf-8-sig")
+        print(f"merged {len(dfs)} shard(s) → {len(merged)} profile rows")
+    else:
+        print("no horse_profiles.csv shards found")
+
+    # ── 3. Append failure logs ────────────────────────────────────────────
+    for name in ("failed_horses.log", "failed_trackwork.log", "failed_injury.log"):
+        dst_path = ROOT / name
+        appended = 0
+        with open(dst_path, "a", encoding="utf-8") as dst:
+            for src in ART.rglob(name):
+                try:
+                    dst.write(src.read_text(encoding="utf-8"))
+                    appended += 1
+                except Exception as e:
+                    print(f"  skip {src}: {e}")
+        if appended:
+            print(f"  appended {appended} {name} file(s)")
+
+    # ── 4. Preserve injury horseid map (single copy; all shards identical) ─
+    for src in ART.rglob("horses/injury/_horseid_map.json"):
+        shutil.copy2(src, ROOT / "horses" / "injury" / "_horseid_map.json")
+        print(f"  copied {src.name}")
+        break
+
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("usage: merge_pool_a_artifacts.py <artifact-dir>", file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
## Root cause

`capy_pool_a.yml` ran 3 scrapers sequentially in a single `ubuntu-latest` job. GitHub-hosted runners enforce a **6-hour hard per-job timeout** — the YAML's `timeout-minutes: 720` was silently capped at 360 by GitHub's policy.

Last 3 force-dispatches all hit the cap:

| Run | Duration | Result |
|---|---|---|
| `24881750023` | 345.8 min | cancelled |
| `24884086348` | 345.4 min | cancelled |
| `24925481859` | 365.1 min | cancelled |

Consequence: `horses/profiles/horse_profiles.csv` has not been updated since **2026-04-23T06:25Z** (Replit VM's final backup). `data/pool_a_horses.csv` flagged MISSING in SANITY. Critical audit frozen at 2,557.

`HorseData_Scraper.py` alone needs ~7.2h (~1300 horses × ~20s) for a cold first-pass — never fits in one 6h job.

## New architecture

```
guard  -> horse-data[0..3]  -+-> horse-trackwork[0..3]  -+-> push
                             +-> horse-injury            +
```

- **4 parallel shards** each get their own 6h budget (18h HorseData headroom vs 7.2h need)
- Shard partitioning via `zlib.crc32(horse_no) % 4` (deterministic, no PYTHONHASHSEED issues)
- Per-horse files (`form_<hno>.csv`, `trackwork_<hno>.csv`, `injury_<hno>.csv`) have no cross-shard collision by construction
- `HorseInjury` stays single-job (requests-based, ~80 min for full roster)
- Final `push` job merges artefacts via `scripts/merge_pool_a_artifacts.py` → single commit via existing `git_sync.py`

## Changes

- `HorseData_Scraper.py` — added `--shard` / `--total-shards` CLI + CRC32 filter (~10 lines, backward-compatible; `total_shards=1` = original behaviour)
- `HorseTrackwork_Scraper.py` — same CLI pattern, filter applied before the `done` subtraction so per-shard accounting is correct
- `scripts/merge_pool_a_artifacts.py` — new. Concats shard `horse_profiles.csv` copies, dedupes on `horse_no` with `profile_last_scraped` tie-break (prefers newly-scraped row over stale baseline)
- `.github/workflows/capy_pool_a.yml` — full rewrite: `guard → horse-data[0..3] → horse-trackwork[0..3] + horse-injury → push`, `timeout-minutes: 350` per job, `fail-fast: false`, `if: always()` on downstream so partial success still produces data
- `HorseInjury_Scraper.py` — **unchanged**
- `git_sync.py`, `fixture_guard.sh`, `comeback_detection.py`, etc. — **unchanged**

## Verification plan

1. Merge this PR
2. Force-dispatch `capy_pool_a.yml` with `force=true`
3. Confirm all 10 jobs start (1 guard + 4 data + 4 trackwork + 1 injury + 1 push)
4. Each shard should finish ≤ 1.8h — no timeouts expected
5. Merge step log should report `merged 4 shard(s) → N profile rows` with N ≈ 12,000+
6. Commit `[data][skip ci] pool-a ... via GHA matrix` lands on main
7. Next SANITY tick (04:41Z next day) shows critical count dropping from 2,557

## Rollback

If anything breaks, `git revert` this PR commit restores the old single-job workflow.

## Follow-up (not in this PR)

Once the baseline is current, add Option C — delta-only daily mode — so scheduled runs only rescrape `last_race_date >= today-14d` + today's entry list. That shrinks daily wallclock to ~10 min and drops the shards back to serialized for long-term cost.

---

Investigation + design done by the Capy assistant (Claude Opus 4.7) on behalf of @sleepingarhat, 2026-04-25.